### PR TITLE
feat: enable rust manager to detect rust-toolchain.toml

### DIFF
--- a/default.json
+++ b/default.json
@@ -13,10 +13,11 @@
     "schedule": ["at any time"]
   },
   "reviewers": ["team:admin-team"],
-  "rust-toolchain": {
-    "enabled": true
-  },
   "packageRules": [
+    {
+      "matchCategories": ["rust"],
+      "enabled": true
+    },
     {
       "description": "Automerge non-major updates",
       "minimumReleaseAge": "7 days",

--- a/default.json
+++ b/default.json
@@ -13,6 +13,9 @@
     "schedule": ["at any time"]
   },
   "reviewers": ["team:admin-team"],
+  "rust": {
+    "enabled": true
+  },
   "packageRules": [
     {
       "description": "Automerge non-major updates",

--- a/default.json
+++ b/default.json
@@ -13,11 +13,10 @@
     "schedule": ["at any time"]
   },
   "reviewers": ["team:admin-team"],
+  "rust-toolchain": {
+    "enabled": true
+  },
   "packageRules": [
-    {
-      "matchCategories": ["rust"],
-      "enabled": true
-    },
     {
       "description": "Automerge non-major updates",
       "minimumReleaseAge": "7 days",

--- a/default.json
+++ b/default.json
@@ -13,10 +13,11 @@
     "schedule": ["at any time"]
   },
   "reviewers": ["team:admin-team"],
-  "rust": {
-    "enabled": true
-  },
   "packageRules": [
+    {
+      "matchCategories": ["rust"],
+      "enabled": true
+    },
     {
       "description": "Automerge non-major updates",
       "minimumReleaseAge": "7 days",


### PR DESCRIPTION
  ## Summary
  - `rust` マネージャーを明示的に有効化し、`rust-toolchain.toml` の `channel` バージョンを Renovate
  が検出・更新できるようにした

  🤖 Generated with [Claude Code](https://claude.com/claude-code)